### PR TITLE
Fix incorrect `mvt` path after `pip3 install` and assorted cleanups

### DIFF
--- a/pegasus_scanner.command
+++ b/pegasus_scanner.command
@@ -2,44 +2,59 @@
 
 
 BASE_MVT=""
+
 # Check if mvt is already installed
-BREW_MVT_IOS=/usr/local/bin/mvt-ios
-USERDIR_MVT=~/Library/Python/3.8/bin/mvt-ios
-if [ -x $BREW_MVT_IOS ]; then
-    BASE_MVT=/usr/local/bin
+MVT_IOS="mvt-ios"
+MVT_ANDROID="mvt-android"
+PYTHON_VER=$(python3 -V|cut -d" " -f2)
+
+BREW_BASE_MVT="/usr/local/bin"
+BREW_MVT="${BREW_BASE_MVT}/${MVT_IOS}"
+
+USERDIR_BASE_MVT="${HOME}/Library/Python/${PYTHON_VER%.*}/bin"
+USERDIR_MVT="${USERDIR_BASE_MVT}/${MVT_IOS}"
+
+if [ -x "${BREW_MVT}" ]; then
+    BASE_MVT=${BREW_BASE_MVT}
 fi
-if [ -x $USERDIR_MVT ]; then
-    BASE_MVT=~/Library/Python/3.8/bin
+if [ -x "${USERDIR_MVT}" ]; then
+    BASE_MVT=${USERDIR_BASE_MVT}
 fi
 
-if [ "$BASE_MVT" = "" ]; then
+if [ "${BASE_MVT}" = "" ]; then
     echo "Installing MVT"
     pip3 install mvt --user
+    BASE_MVT=${USERDIR_BASE_MVT}
 fi
 
 DEVICE_CHOICE=0
 until [ $DEVICE_CHOICE -eq 1 ] || [ $DEVICE_CHOICE -eq 2 ]; do
-    echo "do you want to scan"
+    echo 
+    echo "What do you want to scan?"
     echo " 1) Android Device"
     echo " 2) iOS Device"
-    read DEVICE_CHOICE
+    read -r DEVICE_CHOICE
 done
 
-if [ $DEVICE_CHOICE -eq 1 ]; then
-    echo "Connect your Android Device now, then press Enter"
-    read
-    $BASE_MVT/mvt-android check-adb
-else
-    if [ $DEVICE_CHOICE -eq 2 ]; then
+echo 
+
+case $DEVICE_CHOICE in
+    1 )
+        echo "Connect your Android Device now, then press Enter"
+        read -r
+        "${BASE_MVT}/${MVT_ANDROID}" check-adb
+        ;;
+    2 )
         echo "Locating your iPhone backups"
-        ls -l ~/Library/Application\ Support/MobileSync/Backup
+        BACKUP_DIR="${HOME}/Library/Application Support/MobileSync/Backup"
+        ls -l "${BACKUP_DIR}"
         BACKUP_IPHONE="invalid_folder"
-        until [ -d ~/Library/Application\ Support/MobileSync/Backup/$BACKUP_IPHONE ]; do
-            echo "Copy/paste the back you which to scan"
-            read BACKUP_IPHONE
+        until [ -d "${BACKUP_DIR}/${BACKUP_IPHONE}" ]; do
+            echo 
+            echo "Copy/paste the name of the backup you wish to scan"
+            read -r BACKUP_IPHONE
         done
 
-        $BASE_MVT/mvt-ios check-backup ~/Library/Application\ Support/MobileSync/Backup/$BACKUP_IPHONE
-    fi
-fi
-
+        "${BASE_MVT}/${MVT_IOS}" check-backup "${BACKUP_DIR}/${BACKUP_IPHONE}"
+        ;;
+esac


### PR DESCRIPTION
- `BASE_MVT` was not set after running `pip3 install`, so the executable could not be located
- Extracts various repeated paths in variables
- Extracts the python3 version currently installed instead of hardcoding 3.8
- Adds quotes around paths and fixes assorted issues revealed by static analysis (`shellcheck`)
- Rewrites some of the user-facing prompts

Thanks for taking the time to write the script :)